### PR TITLE
Fix hair desync at high frame rates; stabilize IL hooks; pin .NET SDK

### DIFF
--- a/Source/MotionSmoothing.csproj
+++ b/Source/MotionSmoothing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>Celeste.Mod.MotionSmoothing</RootNamespace>
         <LangVersion>latest</LangVersion>
         <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\..\Celeste.dll')">..\..\..</CelestePrefix>

--- a/Source/Smoothing/MotionSmoothingHandler.cs
+++ b/Source/Smoothing/MotionSmoothingHandler.cs
@@ -23,6 +23,7 @@ public class MotionSmoothingHandler : ToggleableFeature<MotionSmoothingHandler>
 
     public ValueSmoother ValueSmoother { get; } = new();
     public PushSpriteSmoother PushSpriteSmoother { get; } = new();
+    public HairSmoother HairSmoother { get; } = new();
 
     private readonly Stopwatch _timer = Stopwatch.StartNew();
     private long _lastTicks;
@@ -40,6 +41,7 @@ public class MotionSmoothingHandler : ToggleableFeature<MotionSmoothingHandler>
         base.Enable();
         ValueSmoother.Enable();
         PushSpriteSmoother.Enable();
+        HairSmoother.Enable();
 
         SmoothAllObjects();
     }
@@ -49,6 +51,7 @@ public class MotionSmoothingHandler : ToggleableFeature<MotionSmoothingHandler>
         base.Disable();
         ValueSmoother.Disable();
         PushSpriteSmoother.Disable();
+        HairSmoother.Disable();
 
         ValueSmoother.ClearStates();
         PushSpriteSmoother.ClearStates();

--- a/Source/Smoothing/Strategies/HairSmoother.cs
+++ b/Source/Smoothing/Strategies/HairSmoother.cs
@@ -1,0 +1,39 @@
+using Celeste.Mod.MotionSmoothing.Smoothing.States;
+using Celeste.Mod.MotionSmoothing.Utilities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.RuntimeDetour;
+
+namespace Celeste.Mod.MotionSmoothing.Smoothing.Strategies;
+
+public class HairSmoother : ToggleableFeature<HairSmoother>
+{
+    protected override void Hook()
+    {
+        base.Hook();
+        AddHook(new Hook(typeof(PlayerHair).GetMethod("Render")!, PlayerHairRenderHook));
+    }
+
+    private static void PlayerHairRenderHook(On.Celeste.PlayerHair.orig_Render orig, PlayerHair self)
+    {
+        var offset = GetHairOffset(self);
+        if (offset != Vector2.Zero)
+        {
+            for (int i = 0; i < self.Nodes.Count; i++) self.Nodes[i] += offset;
+            try { orig(self); }
+            finally { for (int i = 0; i < self.Nodes.Count; i++) self.Nodes[i] -= offset; }
+            return;
+        }
+        orig(self);
+    }
+
+    private static Vector2 GetHairOffset(PlayerHair hair)
+    {
+        var playerState = (hair.Entity is Player
+            ? MotionSmoothingHandler.Instance.PlayerState
+            : MotionSmoothingHandler.Instance.GetState(hair.Entity)) as IPositionSmoothingState;
+        if (playerState == null) return Vector2.Zero;
+        var targetPos = playerState.SmoothedRealPosition.Round();
+        return targetPos - playerState.OriginalDrawPosition;
+    }
+}

--- a/Source/Smoothing/Strategies/PushSpriteSmoother.cs
+++ b/Source/Smoothing/Strategies/PushSpriteSmoother.cs
@@ -31,8 +31,6 @@ public class PushSpriteSmoother : SmoothingStrategy<PushSpriteSmoother>
         HookComponentRender<Sprite>();
         HookComponentRender<Image>();
         HookComponentRender<DustGraphic>(); // Components (that aren't GraphicsComponents) can be smoothed by looking at their Entity's position
-        // Use a dedicated hook for PlayerHair to apply offset directly during its Render
-        AddHook(new Hook(typeof(PlayerHair).GetMethod("Render")!, PlayerHairRenderHook));
 
         IL.Monocle.ComponentList.Render += ComponentListRenderHook;
         IL.Monocle.EntityList.Render += EntityListRenderHook;
@@ -146,28 +144,6 @@ public class PushSpriteSmoother : SmoothingStrategy<PushSpriteSmoother>
         PreObjectRender(self);
         orig(self);
         PostObjectRender();
-    }
-
-    private static void PlayerHairRenderHook(On.Celeste.PlayerHair.orig_Render orig, PlayerHair self)
-    {
-        var offset = Instance.GetHairOffset(self);
-        if (offset != Vector2.Zero)
-        {
-            for (var i = 0; i < self.Nodes.Count; i++)
-                self.Nodes[i] += offset;
-            try
-            {
-                orig(self);
-            }
-            finally
-            {
-                for (var i = 0; i < self.Nodes.Count; i++)
-                    self.Nodes[i] -= offset;
-            }
-            return;
-        }
-
-        orig(self);
     }
 
     // ReSharper disable once InconsistentNaming

--- a/Source/Smoothing/Strategies/PushSpriteSmoother.cs
+++ b/Source/Smoothing/Strategies/PushSpriteSmoother.cs
@@ -71,7 +71,6 @@ public class PushSpriteSmoother : SmoothingStrategy<PushSpriteSmoother>
         position += obj switch
         {
             GraphicsComponent graphicsComponent => GetOffset(graphicsComponent) + GetOffset(graphicsComponent.Entity),
-            PlayerHair hair => GetHairOffset(hair),
             Component component => GetOffset(component.Entity),
             _ => GetOffset(obj)
         };
@@ -114,7 +113,8 @@ public class PushSpriteSmoother : SmoothingStrategy<PushSpriteSmoother>
         var c = new ILCursor(il);
         while (c.TryGotoNext(MoveType.Before, i => i.MatchCallvirt<Component>(nameof(Component.Render))))
         {
-            c.Emit(OpCodes.Ldloc_1);
+            // Use Dup to copy the instance about to call Render so we always pass the correct object
+            c.Emit(OpCodes.Dup);
             c.EmitDelegate(PreObjectRender);
             c.Index++;
             c.EmitDelegate(PostObjectRender);
@@ -126,7 +126,8 @@ public class PushSpriteSmoother : SmoothingStrategy<PushSpriteSmoother>
         var c = new ILCursor(il);
         while (c.TryGotoNext(MoveType.Before, i => i.MatchCallvirt<Entity>(nameof(Entity.Render))))
         {
-            c.Emit(OpCodes.Ldloc_1);
+            // Use Dup to copy the instance about to call Render so we always pass the correct object
+            c.Emit(OpCodes.Dup);
             c.EmitDelegate(PreObjectRender);
             c.Index++;
             c.EmitDelegate(PostObjectRender);

--- a/Source/Smoothing/Strategies/PushSpriteSmoother.cs
+++ b/Source/Smoothing/Strategies/PushSpriteSmoother.cs
@@ -31,7 +31,8 @@ public class PushSpriteSmoother : SmoothingStrategy<PushSpriteSmoother>
         HookComponentRender<Sprite>();
         HookComponentRender<Image>();
         HookComponentRender<DustGraphic>(); // Components (that aren't GraphicsComponents) can be smoothed by looking at their Entity's position
-        HookComponentRender<PlayerHair>();
+        // Use a dedicated hook for PlayerHair to apply offset directly during its Render
+        AddHook(new Hook(typeof(PlayerHair).GetMethod("Render")!, PlayerHairRenderHook));
 
         IL.Monocle.ComponentList.Render += ComponentListRenderHook;
         IL.Monocle.EntityList.Render += EntityListRenderHook;
@@ -144,6 +145,28 @@ public class PushSpriteSmoother : SmoothingStrategy<PushSpriteSmoother>
         PreObjectRender(self);
         orig(self);
         PostObjectRender();
+    }
+
+    private static void PlayerHairRenderHook(On.Celeste.PlayerHair.orig_Render orig, PlayerHair self)
+    {
+        var offset = Instance.GetHairOffset(self);
+        if (offset != Vector2.Zero)
+        {
+            for (var i = 0; i < self.Nodes.Count; i++)
+                self.Nodes[i] += offset;
+            try
+            {
+                orig(self);
+            }
+            finally
+            {
+                for (var i = 0; i < self.Nodes.Count; i++)
+                    self.Nodes[i] -= offset;
+            }
+            return;
+        }
+
+        orig(self);
     }
 
     // ReSharper disable once InconsistentNaming

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
- Problem: At high frame rates, the player hair visually lags/desyncs from the player.
- Root cause: PlayerHair.Render draws segments directly from Nodes via MTexture.Draw and does not go through SpriteBatch.PushSprite. Our smoothing offsets were only applied on the PushSprite path, so the hair never received the offset.
- Fix: Hook PlayerHair.Render; apply smoothed offset to Nodes before draw, restore after.
- IL: Use OpCodes.Dup instead of Ldloc_1 to reliably capture Render instance.
- Tooling: Add global.json to pin .NET SDK (8.0.x).
- Test: Hair stays in sync at high FPS now.

Note: Those changes are 80% made by AI actually. I've verified that the hair bug is really fixed XD