### PR TITLE
Added trigger "Set Session Motion Smoothing Settings"

### DIFF
--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -1,0 +1,17 @@
+mods.MotionSmoothing.name=Motion Smoothing
+
+# Triggers
+
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.placements.name.set_session_motion_smoothing_settings=Set Session Motion Smoothing Settings
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.placements.description.set_session_motion_smoothing_settings=On enter, temporarily replaces some or all of the players current Motion Smoothing settings with those set by the mapper,\n\nOnly applies to the current map.
+
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.enabled=Changes whether or not Motion Smoothing is enabled for the player in the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.framerate=Changes the players Framerate for the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.smoothCamera=Changes the players camera smoothing strategy for the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.renderMadelineWithSubpixelPrecision=Changes whether or not Madeline is rendered with subpixel precision for the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.smoothBackground=Changes whether or not the games Background is smoothed for the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.smoothForeground=Changes whether or not the games Foreground is smoothed for the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.hideStretchedLevelEdges=Changes whether or not to hide stretched level edges for the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.objectSmoothing=Changes the players object smoothing mode for the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.framerateIncreaseMethod=Changes the players framerate increase method for the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.
+triggers.MotionSmoothing/SetSessionMotionSmoothingSettings.attributes.description.nastyMode=Changes whether or not Nasty Mode is enabled for the maps current session,\n\n"Ignore" doesn't change anything and leaves this setting as it currently is.

--- a/Loenn/triggers/set_session_motion_smoothing_settings.lua
+++ b/Loenn/triggers/set_session_motion_smoothing_settings.lua
@@ -1,0 +1,135 @@
+local SetSessionMotionSmoothingSettings = {}
+
+SetSessionMotionSmoothingSettings.name = "MotionSmoothing/SetSessionMotionSmoothingSettings"
+
+SetSessionMotionSmoothingSettings.placements = {
+    name = "set_session_motion_smoothing_settings",
+    data = {
+        width = 16,
+        height = 16,
+		enabled = "Ignore",
+		framerate = "Ignore",
+		smoothCamera = "Ignore",
+		renderMadelineWithSubpixelPrecision = "Ignore",
+		smoothBackground = "Ignore",
+		smoothForeground = "Ignore",
+		hideStretchedLevelEdges = "Ignore",
+		objectSmoothing = "Ignore",
+		framerateIncreaseMethod = "Ignore",
+		nastyMode = "Ignore"
+    }
+}
+
+SetSessionMotionSmoothingSettings.fieldOrder = {
+	"x", "y",
+	"width", "height",
+	"editorColor", "enabled",
+	"framerate", "smoothCamera",
+	"renderMadelineWithSubpixelPrecision", "smoothBackground",
+	"smoothForeground", "hideStretchedLevelEdges",
+	"objectSmoothing", "framerateIncreaseMethod",
+	"nastyMode"
+}
+
+SetSessionMotionSmoothingSettings.fieldInformation = {
+	enabled = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"OFF",
+			"ON"
+		},
+		editable = false
+	},
+	framerate = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"60",
+			"120",
+			"180",
+			"240",
+			"300",
+			"360",
+			"420",
+			"480"
+		},
+		editable = false
+	},
+	smoothCamera = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"Fancy",
+			"Fast",
+			"Off"
+		},
+		editable = false
+	},
+	renderMadelineWithSubpixelPrecision = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"OFF",
+			"ON"
+		},
+		editable = false
+	},
+	smoothBackground = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"OFF",
+			"ON"
+		},
+		editable = false
+	},
+	smoothForeground = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"OFF",
+			"ON"
+		},
+		editable = false
+	},
+	hideStretchedLevelEdges = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"OFF",
+			"ON"
+		},
+		editable = false
+	},
+	objectSmoothing = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"Extrapolate",
+			"Interpolate",
+			"Off"
+		},
+		editable = false
+	},
+	framerateIncreaseMethod = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"Interval",
+			"Dynamic"
+		},
+		editable = false
+	},
+	nastyMode = {
+		fieldType = "string",
+		options = {
+			"Ignore",
+			"OFF",
+			"ON"
+		},
+		editable = false
+	}
+}
+
+return SetSessionMotionSmoothingSettings

--- a/Source/MotionSmoothing.csproj
+++ b/Source/MotionSmoothing.csproj
@@ -43,6 +43,10 @@
         <Reference Include="$(CelestePrefix)\Mods\Cache\SpirialisHelper.Spirialis.dll" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Folder Include="Triggers\" />
+    </ItemGroup>
+
     <Target Name="CopyFiles" AfterTargets="Build" Inputs="$(OutputPath)\$(AssemblyName).dll;$(OutputPath)\$(AssemblyName).pdb" Outputs="..\bin\$(AssemblyName).dll;..\bin\$(AssemblyName).pdb">
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="..\bin" />
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).pdb" DestinationFolder="..\bin" />

--- a/Source/MotionSmoothingInputHandler.cs
+++ b/Source/MotionSmoothingInputHandler.cs
@@ -43,11 +43,11 @@ public class MotionSmoothingInputHandler : ToggleableFeature<MotionSmoothingInpu
             if (MotionSmoothingModule.Settings.ButtonToggleMotionSmoothingEnabled.Pressed)
             {
                 Logger.Log(LogLevel.Info, "MotionSmoothingInputHandler", "Toggling motion smoothing");
-                MotionSmoothingModule.Settings.Enabled = !MotionSmoothingModule.Settings.Enabled;
+                MotionSmoothingModule.Instance.CurrentEnabled = !MotionSmoothingModule.Instance.CurrentEnabled;
 
                 MotionSmoothingMessage.Show(
                     "motion_smoothing_enabled",
-                    MotionSmoothingModule.Settings.Enabled ? "Motion Smoothing Enabled" : "Motion Smoothing Disabled",
+                    MotionSmoothingModule.Instance.CurrentEnabled ? "Motion Smoothing Enabled" : "Motion Smoothing Disabled",
                     y: 980f
                 );
             }
@@ -56,31 +56,31 @@ public class MotionSmoothingInputHandler : ToggleableFeature<MotionSmoothingInpu
 
             else if (MotionSmoothingModule.Settings.ButtonChangeCameraSmoothingMode.Pressed)
             {
-                if (!MotionSmoothingModule.Settings.Enabled)
+                if (!MotionSmoothingModule.Instance.CurrentEnabled)
                 {
                     return;
                 }
 
                 Logger.Log(LogLevel.Info, "MotionSmoothingInputHandler", "Toggling unlock strategy");
 
-                if (MotionSmoothingModule.Settings.UnlockCameraStrategy == UnlockCameraStrategy.Hires)
+                if (MotionSmoothingModule.Instance.CurrentUnlockCameraStrategy == UnlockCameraStrategy.Hires)
                 {
-                    MotionSmoothingModule.Settings.UnlockCameraStrategy = UnlockCameraStrategy.Unlock;
+                    MotionSmoothingModule.Instance.CurrentUnlockCameraStrategy = UnlockCameraStrategy.Unlock;
                 }
 
-                else if (MotionSmoothingModule.Settings.UnlockCameraStrategy == UnlockCameraStrategy.Unlock)
+                else if (MotionSmoothingModule.Instance.CurrentUnlockCameraStrategy == UnlockCameraStrategy.Unlock)
                 {
-                    MotionSmoothingModule.Settings.UnlockCameraStrategy = UnlockCameraStrategy.Off;
+                    MotionSmoothingModule.Instance.CurrentUnlockCameraStrategy = UnlockCameraStrategy.Off;
                 }
 
                 else
                 {
-                    MotionSmoothingModule.Settings.UnlockCameraStrategy = UnlockCameraStrategy.Hires;
+                    MotionSmoothingModule.Instance.CurrentUnlockCameraStrategy = UnlockCameraStrategy.Hires;
                 }
 
-				var strategyString = MotionSmoothingModule.Settings.UnlockCameraStrategy == UnlockCameraStrategy.Hires
+				var strategyString = MotionSmoothingModule.Instance.CurrentUnlockCameraStrategy == UnlockCameraStrategy.Hires
 					? "Fancy"
-					: MotionSmoothingModule.Settings.UnlockCameraStrategy == UnlockCameraStrategy.Unlock
+					: MotionSmoothingModule.Instance.CurrentUnlockCameraStrategy == UnlockCameraStrategy.Unlock
 						? "Fast"
 						: "Off";
 

--- a/Source/MotionSmoothingModule.cs
+++ b/Source/MotionSmoothingModule.cs
@@ -24,6 +24,9 @@ public class MotionSmoothingModule : EverestModule
 
     public override Type SettingsType => typeof(MotionSmoothingSettings);
     public static MotionSmoothingSettings Settings => (MotionSmoothingSettings)Instance._Settings;
+    
+    public override Type SessionType => typeof(MotionSmoothingSession);
+    public static MotionSmoothingSession Session => (MotionSmoothingSession)Instance._Session;
 
     public bool InLevel => Engine.Scene is Level || Engine.Scene is LevelLoader ||
                            Engine.Scene is LevelExit || Engine.Scene is Emulator;
@@ -41,10 +44,65 @@ public class MotionSmoothingModule : EverestModule
         Logger.SetLogLevel(nameof(MotionSmoothingModule), LogLevel.Info);
 #endif
     }
+    
+    public bool HasForcedSetSettings => Settings.AllowMapChanges && Session?.MapWantsToForceSetSettings != null;
+
+    public bool CurrentEnabled
+    {
+	    get => HasForcedSetSettings ? Session.MapSetEnabled : Settings.Enabled;
+	    set
+	    {
+		    if (HasForcedSetSettings)
+		    {
+			    Session.MapSetEnabled = value;
+		    }
+		    else
+		    {
+			    Settings.Enabled = value;
+		    }
+	    }
+    }
+    public int CurrentFrameRate => HasForcedSetSettings ? Session.MapSetFrameRate : Settings.FrameRate;
+    public UnlockCameraStrategy CurrentUnlockCameraStrategy
+    {
+	    get => HasForcedSetSettings ? Session.MapSetUnlockCameraStrategy : Settings.UnlockCameraStrategy;
+	    set
+	    {
+		    if (HasForcedSetSettings)
+		    {
+			    Session.MapSetUnlockCameraStrategy = value;
+		    }
+		    else
+		    {
+			    Settings.UnlockCameraStrategy = value;
+		    }
+	    }
+    }
+    public bool CurrentRenderMadelineWithSubpixels => HasForcedSetSettings ? Session.MapSetRenderMadelineWithSubpixels : Settings.RenderMadelineWithSubpixels;
+    public bool CurrentRenderBackgroundHires => HasForcedSetSettings ? Session.MapSetRenderBackgroundHires : Settings.RenderBackgroundHires;
+    public bool CurrentRenderForegroundHires => HasForcedSetSettings ? Session.MapSetRenderForegroundHires : Settings.RenderForegroundHires;
+    public bool CurrentHideStretchedEdges => HasForcedSetSettings ? Session.MapSetHideStretchedEdges : Settings.HideStretchedEdges;
+    public SmoothingMode CurrentObjectSmoothing => HasForcedSetSettings ? Session.MapSetObjectSmoothing : Settings.ObjectSmoothing;
+    public UpdateMode CurrentFramerateIncreaseMethod => HasForcedSetSettings ? Session.MapSetFramerateIncreaseMethod : Settings.FramerateIncreaseMethod;
+    public bool CurrentNastyMode
+    {
+	    get => HasForcedSetSettings ? Session.MapSetNastyMode : Settings.NastyMode;
+	    set
+	    {
+		    if (HasForcedSetSettings)
+		    {
+			    Session.MapSetNastyMode = value;
+		    }
+		    else
+		    {
+			    Settings.NastyMode = value;
+		    }
+	    }
+    }
 
     public List<Action<bool>> EnabledActions { get; } = new();
 
-    public IFrameUncapStrategy FrameUncapStrategy => Settings.FramerateIncreaseMethod switch
+    public IFrameUncapStrategy FrameUncapStrategy => CurrentFramerateIncreaseMethod switch
     {
         UpdateMode.Interval => UpdateEveryNTicks,
         UpdateMode.Dynamic => DecoupledGameTick,
@@ -128,7 +186,7 @@ public class MotionSmoothingModule : EverestModule
 	{
         CelesteTasInterop.Load();
 
-		Settings.SillyMode = false;
+		CurrentNastyMode = false;
 
 		ApplySettings();
 	}
@@ -145,7 +203,7 @@ public class MotionSmoothingModule : EverestModule
     {
         if (MotionSmoothing == null) return;
 
-        if (!Settings.Enabled)
+        if (!CurrentEnabled)
         {
             UpdateEveryNTicks.Disable();
             DecoupledGameTick.Disable();
@@ -167,7 +225,7 @@ public class MotionSmoothingModule : EverestModule
 
 
         // If the game speed is modified, then we have to use dynamic mode
-        if (Settings.FramerateIncreaseMethod == UpdateMode.Dynamic || Settings.GameSpeedModified)
+        if (CurrentFramerateIncreaseMethod == UpdateMode.Dynamic || Settings.GameSpeedModified)
         {
             UpdateEveryNTicks.Disable();
             DecoupledGameTick.Enable();
@@ -198,7 +256,7 @@ public class MotionSmoothingModule : EverestModule
         DebugRenderFix.Enable();
         DeltaTimeFix.Enable();
 
-        if (Settings.UnlockCameraStrategy == UnlockCameraStrategy.Hires)
+        if (CurrentUnlockCameraStrategy == UnlockCameraStrategy.Hires)
         {
             UnlockedCameraSmoother.Disable();
             HiresCameraSmoother.Enable();
@@ -209,10 +267,10 @@ public class MotionSmoothingModule : EverestModule
             // deal with that than to start over with them.
             HiresCameraSmoother.InitializeLargeTextures();
 
-			HiresCameraSmoother.ZoomScale = Settings.HideStretchedEdges ? 181f / 180f : 1;
+			HiresCameraSmoother.ZoomScale = CurrentHideStretchedEdges ? 181f / 180f : 1;
 			HiresCameraSmoother.ZoomMatrix = Matrix.CreateScale(HiresCameraSmoother.ZoomScale);
 
-			if (Settings.RenderMadelineWithSubpixels && !Settings.SillyMode)
+			if (CurrentRenderMadelineWithSubpixels && !CurrentNastyMode)
 			{
 				HiresCameraSmoother.EnableHiresDistort();
 			}
@@ -222,18 +280,18 @@ public class MotionSmoothingModule : EverestModule
 				HiresCameraSmoother.DisableHiresDistort();
 			}
 
-			if (!Settings.RenderMadelineWithSubpixels && !Settings.SillyMode)
+			if (!CurrentRenderMadelineWithSubpixels && !CurrentNastyMode)
 			{
 				HiresCameraSmoother.DisableLargeGameplayBuffer();
 			}
         }
 
-        else if (Settings.UnlockCameraStrategy == UnlockCameraStrategy.Unlock)
+        else if (CurrentUnlockCameraStrategy == UnlockCameraStrategy.Unlock)
         {
             HiresCameraSmoother.Disable();
             UnlockedCameraSmoother.Enable();
 
-			UnlockedCameraSmoother.ZoomScale = Settings.HideStretchedEdges ? 181f / 180f : 1;
+			UnlockedCameraSmoother.ZoomScale = CurrentHideStretchedEdges ? 181f / 180f : 1;
 			UnlockedCameraSmoother.ZoomMatrix = Matrix.CreateScale(UnlockedCameraSmoother.ZoomScale);
         }
         
@@ -246,7 +304,7 @@ public class MotionSmoothingModule : EverestModule
 
     private void ApplyFramerate()
     {
-        int framerate = Settings.Enabled ? Settings.FrameRate : 60;
+        int framerate = CurrentEnabled ? CurrentFrameRate : 60;
 
         var updateFps = 60.0;
         
@@ -324,7 +382,7 @@ public class MotionSmoothingModule : EverestModule
 
     private static void VsyncHook(On.Monocle.Commands.orig_Vsync orig, bool enabled)
     {
-        if (!Settings.Enabled)
+        if (!Instance.CurrentEnabled)
         {
             orig(enabled);
             return;
@@ -335,7 +393,7 @@ public class MotionSmoothingModule : EverestModule
 
     private static void SetVSyncHook(On.Celeste.MenuOptions.orig_SetVSync orig, bool on)
     {
-        if (!Settings.Enabled)
+        if (!Instance.CurrentEnabled)
         {
             orig(on);
             return;
@@ -362,13 +420,13 @@ public class MotionSmoothingModule : EverestModule
 
 	private void SpeedrunToolBeforeLoadState(Level level)
     {
-		_wasEnabled = Settings.Enabled;
-		Settings.Enabled = false;
+		_wasEnabled = CurrentEnabled;
+		CurrentEnabled = false;
     }
 
     private void SpeedrunToolAfterLoadState(Dictionary<Type, Dictionary<string, object>> savedValues, Level level)
     {
-		Settings.Enabled = _wasEnabled;
+		CurrentEnabled = _wasEnabled;
         MotionSmoothing.SmoothAllObjects();
     }
 
@@ -376,7 +434,7 @@ public class MotionSmoothingModule : EverestModule
 
 	public static Vector2 GetCameraOffset()
     {
-        switch (Settings.UnlockCameraStrategy)
+        switch (Instance.CurrentUnlockCameraStrategy)
         {
             case UnlockCameraStrategy.Hires:
                 return HiresCameraSmoother.GetCameraOffset();
@@ -393,7 +451,7 @@ public class MotionSmoothingModule : EverestModule
 
 	public static Matrix GetLevelZoomMatrix()
 	{
-		switch (Settings.UnlockCameraStrategy)
+		switch (Instance.CurrentUnlockCameraStrategy)
 		{
 			case UnlockCameraStrategy.Hires:
 				return HiresCameraSmoother.ZoomMatrix;
@@ -442,7 +500,7 @@ public class MotionSmoothingModule : EverestModule
 
 	public static void ReloadLargeTextures()
 	{
-		if (Settings.UnlockCameraStrategy == UnlockCameraStrategy.Hires && GameplayBuffers.Gameplay is VirtualRenderTarget)
+		if (Instance.CurrentUnlockCameraStrategy == UnlockCameraStrategy.Hires && GameplayBuffers.Gameplay is VirtualRenderTarget)
 		{
 			HiresCameraSmoother.InitializeLargeTextures();
 		}

--- a/Source/MotionSmoothingSession.cs
+++ b/Source/MotionSmoothingSession.cs
@@ -1,0 +1,26 @@
+﻿namespace Celeste.Mod.MotionSmoothing;
+
+public class MotionSmoothingSession : EverestModuleSession
+{
+    public bool? MapWantsToForceSetSettings { get; set; }
+
+    public bool MapSetEnabled { get; set; }
+
+    public int MapSetFrameRate { get; set; }
+
+    public UnlockCameraStrategy MapSetUnlockCameraStrategy { get; set; }
+
+    public bool MapSetRenderMadelineWithSubpixels { get; set; }
+    
+    public bool MapSetRenderBackgroundHires  { get; set; }
+    
+    public bool MapSetRenderForegroundHires  { get; set; }
+    
+    public bool MapSetHideStretchedEdges  { get; set; }
+
+    public SmoothingMode MapSetObjectSmoothing { get; set; }
+    
+    public UpdateMode MapSetFramerateIncreaseMethod { get; set; }
+
+    public bool MapSetNastyMode { get; set; }
+}

--- a/Source/MotionSmoothingSettings.cs
+++ b/Source/MotionSmoothingSettings.cs
@@ -42,8 +42,9 @@ public class MotionSmoothingSettings : EverestModuleSettings
 	private bool _hideStretchedEdges = true;
     private SmoothingMode _smoothingMode = SmoothingMode.Extrapolate;
     private UpdateMode _updateMode = UpdateMode.Interval;
+    private bool _allowMapChanges = true;
 
-	private bool _sillyMode = false;
+	private bool _nastyMode = false;
 
     // Used for compatibility with Viv's game speed mod
     private double _gameSpeed = 60;
@@ -56,7 +57,7 @@ public class MotionSmoothingSettings : EverestModuleSettings
     private TextMenu.Item _renderForegroundHiresItem;
 	private TextMenu.Item _hideStretchedEdgesItem;
 
-	private TextMenu.Item _sillyModeItem;
+	private TextMenu.Item _nastyModeItem;
 
     public bool Enabled
     {
@@ -186,8 +187,8 @@ public class MotionSmoothingSettings : EverestModuleSettings
             _hideStretchedEdgesItem.Disabled = shouldDisableHideStretchedEdges;
             _hideStretchedEdgesItem.Selectable = !shouldDisableHideStretchedEdges;
 
-			_sillyModeItem.Disabled = shouldDisableRenderBackgroundHires;
-            _sillyModeItem.Selectable = !shouldDisableRenderBackgroundHires;
+			_nastyModeItem.Disabled = shouldDisableRenderBackgroundHires;
+            _nastyModeItem.Selectable = !shouldDisableRenderBackgroundHires;
         });
 
         menu.Add(strategySlider);
@@ -456,6 +457,19 @@ public class MotionSmoothingSettings : EverestModuleSettings
             MotionSmoothingModule.Instance.ApplySettings();
         }
     }
+    
+    [SettingSubText(
+        "Allows maps to *temporarily* change your Motion Smoothing settings for the current maps session.\n" +
+        "Disabling this forces your current settings and won't allow maps to change them.")]
+    public bool AllowMapChanges
+    {
+        get => _allowMapChanges;
+        set
+        {
+            _allowMapChanges = value;
+            MotionSmoothingModule.Instance.ApplySettings();
+        }
+    }
 
     [SettingSubText(
         "*** This does not affect gameplay in levels! ***\n" +
@@ -501,36 +515,36 @@ public class MotionSmoothingSettings : EverestModuleSettings
 
 
 
-	public bool SillyMode
+	public bool NastyMode
     {
-        get => _sillyMode;
+        get => _nastyMode;
         set
         {
-            _sillyMode = value;
+            _nastyMode = value;
             MotionSmoothingModule.Instance.ApplySettings();
         }
     }
 
-    public void CreateSillyModeEntry(TextMenu menu, bool inGame)
+    public void CreateNastyModeEntry(TextMenu menu, bool inGame)
     {
-        _sillyModeItem = new TextMenu.OnOff(
+        _nastyModeItem = new TextMenu.OnOff(
             "Nasty Mode",
-            _sillyMode
+            _nastyMode
         );
 
-        (_sillyModeItem as TextMenu.OnOff).Change(value =>
+        (_nastyModeItem as TextMenu.OnOff).Change(value =>
         {
-            SillyMode = value;
+            NastyMode = value;
         });
 
         // Set initial state based on UnlockCameraStrategy
         bool shouldDisable = UnlockCameraStrategy != UnlockCameraStrategy.Hires;
-        _sillyModeItem.Disabled = shouldDisable;
-        _sillyModeItem.Selectable = !shouldDisable;
+        _nastyModeItem.Disabled = shouldDisable;
+        _nastyModeItem.Selectable = !shouldDisable;
 
-        menu.Add(_sillyModeItem);
+        menu.Add(_nastyModeItem);
 
-        _sillyModeItem.AddDescription(
+        _nastyModeItem.AddDescription(
             menu,
             "Smoothing too close to the sun (:\n\n" +
             "This setting is just for fun because it's technically possible; not\n" +

--- a/Source/Smoothing/MotionSmoothingHandler.cs
+++ b/Source/Smoothing/MotionSmoothingHandler.cs
@@ -145,7 +145,7 @@ public class MotionSmoothingHandler : ToggleableFeature<MotionSmoothingHandler>
         {
             DeltaTimeFix.UpdateFixedDeltaTimeMultiplier();
 
-            var mode = MotionSmoothingModule.Settings.ObjectSmoothing;
+            var mode = MotionSmoothingModule.Instance.CurrentObjectSmoothing;
             var elapsedTicks = Instance._timer.ElapsedTicks - Instance._lastTicks;
             var elapsedSeconds = (double)elapsedTicks / Stopwatch.Frequency;
 

--- a/Source/Smoothing/States/SmoothingStateBase.cs
+++ b/Source/Smoothing/States/SmoothingStateBase.cs
@@ -155,7 +155,7 @@ public abstract class PositionSmoothingState<T> : IPositionSmoothingState
         // through ValueSmoother → SetPosition rather than through PushSpriteSmoother) renders
         // at 1/6-px precision under the 6x composite. SetOriginal restores PreSmoothedPosition
         // after the draw, so physics is unaffected.
-        SetPosition(obj, MotionSmoothingModule.Settings.SillyMode
+        SetPosition(obj, MotionSmoothingModule.Instance.CurrentNastyMode
             ? SmoothedRealPosition
             : SmoothedRealPosition.Round());
     }

--- a/Source/Smoothing/States/SmoothingStates.cs
+++ b/Source/Smoothing/States/SmoothingStates.cs
@@ -143,7 +143,7 @@ public class CameraSmoothingState : PositionSmoothingState<Camera>
         if (mode == SmoothingMode.Off)
             mode = SmoothingMode.Extrapolate;
 
-        var currentStrategy = MotionSmoothingModule.Settings.UnlockCameraStrategy;
+        var currentStrategy = MotionSmoothingModule.Instance.CurrentUnlockCameraStrategy;
         if (_hasLastSmoothedBeforePause && _lastSmoothedStrategy != currentStrategy)
             _hasLastSmoothedBeforePause = false;
 

--- a/Source/Smoothing/Strategies/PushSpriteSmoother.cs
+++ b/Source/Smoothing/Strategies/PushSpriteSmoother.cs
@@ -108,7 +108,7 @@ public class PushSpriteSmoother : SmoothingStrategy<PushSpriteSmoother>
         // 1/6-px hair motion instead of a 6-px grid snap. Anchor stays OriginalDrawPosition
         // (integer) so the offset still lands the head at SmoothedRealPosition and shifts
         // Nodes[1..N] by the same delta.
-        var targetPos = MotionSmoothingModule.Settings.SillyMode
+        var targetPos = MotionSmoothingModule.Instance.CurrentNastyMode
             ? playerState.SmoothedRealPosition
             : playerState.SmoothedRealPosition.Round();
         return targetPos - playerState.OriginalDrawPosition;
@@ -119,7 +119,7 @@ public class PushSpriteSmoother : SmoothingStrategy<PushSpriteSmoother>
         if (GetState(obj) is not IPositionSmoothingState state)
             return Vector2.Zero;
 
-		if (MotionSmoothingModule.Settings.SillyMode)
+		if (MotionSmoothingModule.Instance.CurrentNastyMode)
 		{
 			return state.SmoothedRealPosition - state.OriginalDrawPosition;
 		}

--- a/Source/Smoothing/Targets/HiresCameraSmoother.cs
+++ b/Source/Smoothing/Targets/HiresCameraSmoother.cs
@@ -265,8 +265,8 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
         AddHook(new Hook(typeof(Calc).GetMethod(nameof(Calc.Round), [typeof(Vector2)])!, RoundHook));
 
 		if (
-			MotionSmoothingModule.Settings.RenderMadelineWithSubpixels
-			&& !MotionSmoothingModule.Settings.SillyMode
+			MotionSmoothingModule.Instance.CurrentRenderMadelineWithSubpixels
+			&& !MotionSmoothingModule.Instance.CurrentNastyMode
 		) {
 			EnableHiresDistort();
 		}
@@ -580,13 +580,13 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
 
         ComputeSmoothedCameraData(level);
 
-        _enableLargeLevelBuffer = MotionSmoothingModule.Settings.RenderBackgroundHires;
+        _enableLargeLevelBuffer = MotionSmoothingModule.Instance.CurrentRenderBackgroundHires;
 		_enableLargeGameplayBuffer = false;
     }
 
     private static void AfterLevelClear(Level level)
     {
-        if (MotionSmoothingModule.Settings.RenderBackgroundHires)
+        if (MotionSmoothingModule.Instance.CurrentRenderBackgroundHires)
         {
             _disableFloorFunctions = DisableFloorFunctionsMode.Rational;
         }
@@ -723,7 +723,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
         _offsetWhenDrawnTo.Clear();
         _inverseOffsetWhenDrawnFrom.Clear();
 
-        if (!MotionSmoothingModule.Settings.HideStretchedEdges)
+        if (!MotionSmoothingModule.Instance.CurrentHideStretchedEdges)
         {
             // We only do this a second time here because we're covering up the gap where the bloom was left
             // which will be completely hidden by the zoom, unlike the blooming edges from before.
@@ -804,8 +804,8 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
         }
 
         if (
-            _currentlyRenderingBackground && MotionSmoothingModule.Settings.RenderBackgroundHires
-            || !_currentlyRenderingBackground && MotionSmoothingModule.Settings.RenderForegroundHires
+            _currentlyRenderingBackground && MotionSmoothingModule.Instance.CurrentRenderBackgroundHires
+            || !_currentlyRenderingBackground && MotionSmoothingModule.Instance.CurrentRenderForegroundHires
         ) {
             _disableFloorFunctions = DisableFloorFunctionsMode.Rational;
             orig(self, scene);
@@ -917,7 +917,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
 	private static bool ShouldRenderBackdrop(Backdrop self)
 	{
 		if (
-			MotionSmoothingModule.Settings.RenderBackgroundHires
+			MotionSmoothingModule.Instance.CurrentRenderBackgroundHires
 			|| !_currentlyRenderingBackground
 		) {
 			return true;
@@ -1026,8 +1026,8 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
     {
 		if (
 			HiresRenderer.Instance is not { } renderer
-			|| !MotionSmoothingModule.Settings.RenderMadelineWithSubpixels
-			|| MotionSmoothingModule.Settings.SillyMode
+			|| !MotionSmoothingModule.Instance.CurrentRenderMadelineWithSubpixels
+			|| MotionSmoothingModule.Instance.CurrentNastyMode
 		) {
 			orig(self, scene);
 			return;
@@ -1101,7 +1101,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
 	{
 		if (
 			!_currentlyRenderingGameplay
-			|| !MotionSmoothingModule.Settings.RenderMadelineWithSubpixels
+			|| !MotionSmoothingModule.Instance.CurrentRenderMadelineWithSubpixels
 		) {
 			return false;
 		}
@@ -1218,7 +1218,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
 
     private static void Player_Render(On.Celeste.Player.orig_Render orig, Player self)
     {
-		if (MotionSmoothingModule.Settings.SillyMode)
+		if (MotionSmoothingModule.Instance.CurrentNastyMode)
 		{
 			_disableFloorFunctions = DisableFloorFunctionsMode.Continuous;
 			orig(self);
@@ -1256,7 +1256,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
 		Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, RasterizerState.CullNone, null, Matrix.Identity);
 		Draw.SpriteBatch.Draw(
             renderer.SmallBuffer,
-            MotionSmoothingModule.Settings.RenderMadelineWithSubpixels ? _lastPlayerOffset : Vector2.Zero,
+            MotionSmoothingModule.Instance.CurrentRenderMadelineWithSubpixels ? _lastPlayerOffset : Vector2.Zero,
             Color.White
         );
 		Draw.SpriteBatch.End();
@@ -1288,7 +1288,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
 
 
 
-		if (MotionSmoothingModule.Settings.SillyMode)
+		if (MotionSmoothingModule.Instance.CurrentNastyMode)
 		{
 			Engine.Instance.GraphicsDevice.SetRenderTarget(GameplayBuffers.Gameplay);
 
@@ -1313,7 +1313,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
 
 
 
-		if (!MotionSmoothingModule.Settings.RenderMadelineWithSubpixels)
+		if (!MotionSmoothingModule.Instance.CurrentRenderMadelineWithSubpixels)
 		{
 			// If we're not doing subpixel rendering, then we don't need to do that much.
 			Engine.Instance.GraphicsDevice.SetRenderTarget(renderer.SmallBuffer);
@@ -1691,7 +1691,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
         // Never fall through to _largeExternalTextureMap for these, as other
         // mods swapping buffer targets could bypass the flag checks.
         if (texture == GameplayBuffers.Gameplay.Target)
-            return _enableLargeGameplayBuffer || MotionSmoothingModule.Settings.SillyMode
+            return _enableLargeGameplayBuffer || MotionSmoothingModule.Instance.CurrentNastyMode
 				? renderer.LargeGameplayBuffer
 				: null;
 
@@ -1735,7 +1735,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
 
         // Gameplay and Level: enable flags always take absolute precedence.
         if (texture == GameplayBuffers.Gameplay.Target)
-            return _enableLargeGameplayBuffer || MotionSmoothingModule.Settings.SillyMode
+            return _enableLargeGameplayBuffer || MotionSmoothingModule.Instance.CurrentNastyMode
 				? renderer.LargeGameplayBuffer
 				: texture;
 
@@ -2394,8 +2394,8 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
     private static void FloorVerticesIfNeeded<T>(T[] vertices, int vertexCount) where T : struct, IVertexType
     {
         if (
-            _currentlyRenderingBackground && MotionSmoothingModule.Settings.RenderBackgroundHires
-            || !_currentlyRenderingBackground && MotionSmoothingModule.Settings.RenderForegroundHires
+            _currentlyRenderingBackground && MotionSmoothingModule.Instance.CurrentRenderBackgroundHires
+            || !_currentlyRenderingBackground && MotionSmoothingModule.Instance.CurrentRenderForegroundHires
         ) {
             return;
         }
@@ -2439,7 +2439,7 @@ public class HiresCameraSmoother : ToggleableFeature<HiresCameraSmoother>
 
     private static bool TryDrawPixelated<T>(Matrix matrix, T[] vertices, int vertexCount) where T : struct, IVertexType
     {
-        if (_inPixelatedDraw || vertexCount > 100 || MotionSmoothingModule.Settings.SillyMode)
+        if (_inPixelatedDraw || vertexCount > 100 || MotionSmoothingModule.Instance.CurrentNastyMode)
         {
             return false;
         }

--- a/Source/Smoothing/Targets/PlayerSmoother.cs
+++ b/Source/Smoothing/Targets/PlayerSmoother.cs
@@ -29,7 +29,7 @@ public static class PlayerSmoother
 
     public static Vector2 Smooth(Player player, IPositionSmoothingState state, double elapsed, SmoothingMode mode)
     {
-        var sillyMode = MotionSmoothingModule.Settings.SillyMode;
+        var sillyMode = MotionSmoothingModule.Instance.CurrentNastyMode;
         return mode switch
         {
             SmoothingMode.Interpolate => Interpolate(player, state, elapsed),
@@ -82,7 +82,7 @@ public static class PlayerSmoother
     {
         // SillyMode: snap-back destinations use OriginalRealPosition so we don't drop back
         // onto the integer grid on a pipeline that's otherwise rendering at 1/6-px.
-        var sillyMode = MotionSmoothingModule.Settings.SillyMode;
+        var sillyMode = MotionSmoothingModule.Instance.CurrentNastyMode;
 
         // Disable during screen transitions or pause
         if (Engine.Scene is not Level || Engine.Scene is Level { Transitioning: true } or { Paused: true })
@@ -235,7 +235,7 @@ public static class PlayerSmoother
             || Math.Abs(player.Speed.Y) < 0.001
         );
 
-		if (MotionSmoothingModule.Settings.SillyMode)
+		if (MotionSmoothingModule.Instance.CurrentNastyMode)
 		{
 			IsSmoothingX = true;
 			IsSmoothingY = true;
@@ -268,7 +268,7 @@ public static class PlayerSmoother
             || !canClimb
         );
 
-		if (MotionSmoothingModule.Settings.SillyMode)
+		if (MotionSmoothingModule.Instance.CurrentNastyMode)
 		{
 			AllowSubpixelRenderingX = true;
 			AllowSubpixelRenderingY = true;

--- a/Source/Smoothing/Targets/PositionSmoother.cs
+++ b/Source/Smoothing/Targets/PositionSmoother.cs
@@ -15,7 +15,7 @@ public static class PositionSmoother
         // SillyMode: cancellations and subpixel-ignores still snap *back*, but to the
         // unrounded OriginalRealPosition so we don't introduce 1-px grid snaps on a
         // pipeline that's otherwise rendering at 1/6-px under the 6x composite.
-        var sillyMode = MotionSmoothingModule.Settings.SillyMode;
+        var sillyMode = MotionSmoothingModule.Instance.CurrentNastyMode;
 
         if (mode == SmoothingMode.Off)
         {

--- a/Source/Smoothing/Targets/UnlockedCameraSmoother.cs
+++ b/Source/Smoothing/Targets/UnlockedCameraSmoother.cs
@@ -90,7 +90,7 @@ public class UnlockedCameraSmoother : ToggleableFeature<UnlockedCameraSmoother>
     {
         var offset = GetCameraOffset() * HiresPixelSize;
 
-        if (!MotionSmoothingModule.Settings.HideStretchedEdges)
+        if (!MotionSmoothingModule.Instance.CurrentHideStretchedEdges)
             offset += new Vector2(BorderOffset, BorderOffset);
 
         return Matrix.CreateTranslation(offset.X, offset.Y, 0);
@@ -118,7 +118,7 @@ public class UnlockedCameraSmoother : ToggleableFeature<UnlockedCameraSmoother>
         const int textureWidth = 320;
         const int textureHeight = 180;
 
-        if (MotionSmoothingModule.Settings.HideStretchedEdges)
+        if (MotionSmoothingModule.Instance.CurrentHideStretchedEdges)
             return;
         if (((Level)Engine.Scene).ScreenPadding > 0)
             return;

--- a/Source/Triggers/SetSessionMotionSmoothingSettings.cs
+++ b/Source/Triggers/SetSessionMotionSmoothingSettings.cs
@@ -1,0 +1,132 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
+
+namespace Celeste.Mod.MotionSmoothing.Triggers;
+
+[CustomEntity("MotionSmoothing/SetSessionMotionSmoothingSettings")]
+
+public class SetSessionMotionSmoothingSettings : Trigger
+{
+
+    private readonly string Enabled;
+    private readonly string Framerate;
+    private readonly string SmoothCameraString;
+    private readonly string RenderMadelineWithSubpixelPrecision;
+    private readonly string SmoothBackground;
+    private readonly string SmoothForeground;
+    private readonly string HideStretchedLevelEdges;
+    private readonly string ObjectSmoothingString;
+    private readonly string FramerateIncreaseMethodString;
+    private readonly string NastyMode;
+    
+    private UnlockCameraStrategy SmoothCamera;
+    private SmoothingMode ObjectSmoothing;
+    private UpdateMode FramerateIncreaseMethod;
+    
+    public SetSessionMotionSmoothingSettings(EntityData data, Vector2 offset) : base(data, offset)
+    {
+        Enabled = data.Attr("enabled");
+        Framerate = data.Attr("framerate");
+        SmoothCameraString = data.Attr("smoothCamera");
+        RenderMadelineWithSubpixelPrecision = data.Attr("renderMadelineWithSubpixelPrecision");
+        SmoothBackground = data.Attr("smoothBackground");
+        SmoothForeground = data.Attr("smoothForeground");
+        HideStretchedLevelEdges =  data.Attr("hideStretchedLevelEdges");
+        ObjectSmoothingString = data.Attr("objectSmoothing");
+        FramerateIncreaseMethodString = data.Attr("framerateIncreaseMethod");
+        NastyMode = data.Attr("nastyMode");
+    }
+    
+    public override void OnEnter(Player player)
+    {
+        base.OnEnter(player);
+
+        if (!MotionSmoothingModule.Settings.AllowMapChanges) return;
+
+        MotionSmoothingModule.Session.MapWantsToForceSetSettings = true;
+        
+        MotionSmoothingModule.Session.MapSetEnabled = Enabled switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetEnabled,
+            "OFF" => false,
+            "ON" => true
+        };
+        
+        MotionSmoothingModule.Session.MapSetFrameRate = Framerate switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetFrameRate,
+            "60" => 60,
+            "120" => 120,
+            "180" => 180,
+            "240" => 240,
+            "300" => 300,
+            "360" => 360,
+            "420" => 420,
+            "480" => 480
+        };
+
+        SmoothCamera = SmoothCameraString switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetUnlockCameraStrategy,
+            "Fancy" => UnlockCameraStrategy.Hires,
+            "Fast" => UnlockCameraStrategy.Unlock,
+            "Off" => UnlockCameraStrategy.Off
+        };
+        MotionSmoothingModule.Session.MapSetUnlockCameraStrategy = SmoothCamera;
+        
+        MotionSmoothingModule.Session.MapSetRenderMadelineWithSubpixels = RenderMadelineWithSubpixelPrecision switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetRenderMadelineWithSubpixels,
+            "OFF" => false,
+            "ON" => true
+        };
+        
+        MotionSmoothingModule.Session.MapSetRenderBackgroundHires = SmoothBackground switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetRenderBackgroundHires,
+            "OFF" => false,
+            "ON" => true
+        };
+        
+        MotionSmoothingModule.Session.MapSetRenderForegroundHires = SmoothForeground switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetRenderForegroundHires,
+            "OFF" => false,
+            "ON" => true
+        };
+        
+        MotionSmoothingModule.Session.MapSetHideStretchedEdges = HideStretchedLevelEdges switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetHideStretchedEdges,
+            "OFF" => false,
+            "ON" => true
+        };
+
+        ObjectSmoothing = ObjectSmoothingString switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetObjectSmoothing,
+            "Extrapolate" => SmoothingMode.Extrapolate,
+            "Interpolate" => SmoothingMode.Interpolate,
+            "Off" => SmoothingMode.Off
+        };
+        MotionSmoothingModule.Session.MapSetObjectSmoothing = ObjectSmoothing;
+        
+        FramerateIncreaseMethod = FramerateIncreaseMethodString switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetFramerateIncreaseMethod,
+            "Interval" => UpdateMode.Interval,
+            "Dynamic" => UpdateMode.Dynamic
+        };
+        MotionSmoothingModule.Session.MapSetFramerateIncreaseMethod = FramerateIncreaseMethod;
+
+        MotionSmoothingModule.Session.MapSetNastyMode = NastyMode switch
+        {
+            "Ignore" => MotionSmoothingModule.Session.MapSetNastyMode,
+            "OFF" => false,
+            "ON" => true
+        };
+        
+        MotionSmoothingModule.Instance.ApplySettings();
+    }
+}

--- a/Source/Utilities/ActorPushTracker.cs
+++ b/Source/Utilities/ActorPushTracker.cs
@@ -55,7 +55,7 @@ public class ActorPushTracker : ToggleableFeature<ActorPushTracker>
         // SillyMode: base against the unrounded historical position so a pusher-carried
         // actor on e.g. a diagonal moveblock doesn't snap to the 1-px grid while the rest
         // of the pipeline renders at 1/6-px under the 6x composite.
-        var basePos = MotionSmoothingModule.Settings.SillyMode
+        var basePos = MotionSmoothingModule.Instance.CurrentNastyMode
             ? posState.GetLastRealPosition(mode)
             : posState.GetLastDrawPosition(mode);
         pushed = basePos + offset;
@@ -100,7 +100,7 @@ public class ActorPushTracker : ToggleableFeature<ActorPushTracker>
 
     public Vector2 GetSolidOffset(ISmoothingState state, object obj, double elapsedSeconds, out Vector2 velocity)
     {
-        var mode = MotionSmoothingModule.Settings.ObjectSmoothing;
+        var mode = MotionSmoothingModule.Instance.CurrentObjectSmoothing;
         var interp = mode == SmoothingMode.Interpolate;
         velocity = Vector2.Zero;
 

--- a/Source/Utilities/FrameRateTextMenuItem.cs
+++ b/Source/Utilities/FrameRateTextMenuItem.cs
@@ -26,7 +26,7 @@ public class FrameRateTextMenuItem : TextMenuExt.IntSlider
     {
         _min = min;
         _max = max;
-        UpdateMode = MotionSmoothingModule.Settings.FramerateIncreaseMethod;
+        UpdateMode = MotionSmoothingModule.Instance.CurrentFramerateIncreaseMethod;
     }
 
     private void SetFrameUncapMode(UpdateMode mode)


### PR DESCRIPTION
Adds a trigger that allows mappers to *temporarily* change the players Motion Smoothing Settings just for the current map session the player is in.

Useful for if a mapper knows a specific Motion Smoothing setting will break their map.
Instead of just telling players to disable Motion Smoothing entirely,
the players can just keep it on while any/all conflicting settings are temporarily and automatically turned off by the map.

On the flip side... could be used by the mapper if they think their map is meant to be seen with Motion Smoothing for whatever reason.  

Also Includes a new setting which allows players to ignore map changes and force their specific motion Smoothing settings, keeping the final say with the player instead of the mapper.

https://github.com/user-attachments/assets/cde395c3-419e-449c-bb4c-5909f6cab817